### PR TITLE
basic working version

### DIFF
--- a/keytips.md
+++ b/keytips.md
@@ -1,0 +1,96 @@
+# KeyTips System — Adding New Keytips
+
+This document explains how to add new keyboard shortcut commands to the KeyTips system.
+
+## Architecture Overview
+
+The KeyTips system uses a **trie (prefix tree)** to organize keyboard sequences. Each key press traverses one level deeper into the tree. When a leaf node is reached, its action is executed.
+
+```
+Root
+├── H (Home)
+│   ├── V
+│   │   └── V → Paste Values
+│   ├── B
+│   │   ├── B → Border Bottom
+│   │   └── T → Border Top
+│   └── O
+│       └── I → AutoFit Column
+└── A (Data)
+    └── S → Sort Descending
+```
+
+## How to Add a New KeyTip
+
+### 1. Open `src/keytips/commands.ts`
+
+### 2. Define your command as a `KeyTipCommand` object
+
+```typescript
+const myNewCommand: KeyTipCommand = {
+  keys: ['H', 'F', 'C'],           // Key sequence after Alt/Cmd
+  labels: ['Home', 'Font', 'Color'], // Human-readable label for each level
+  description: 'Change font color',  // Shown in the overlay UI
+  action: (spread) => {
+    // Your SpreadJS logic here
+    const sheet = spread.getActiveSheet();
+    const selections = sheet.getSelections();
+    if (!selections || selections.length === 0) return;
+    const sel = selections[0];
+    // ... apply changes to the selection
+  },
+};
+```
+
+### 3. Add it to the `KEY_TIP_COMMANDS` array
+
+```typescript
+export const KEY_TIP_COMMANDS: KeyTipCommand[] = [
+  pasteValues,
+  borderBottom,
+  borderTop,
+  autoFitColumn,
+  sortDescending,
+  myNewCommand,  // ← add here
+];
+```
+
+That's it. The trie is rebuilt automatically from this array.
+
+## Field Reference
+
+| Field         | Type                                           | Description                                          |
+| ------------- | ---------------------------------------------- | ---------------------------------------------------- |
+| `keys`        | `string[]`                                     | Sequential keys pressed after Alt/Cmd activation     |
+| `labels`      | `string[]`                                     | Display name for each level (shown in path breadcrumb) |
+| `description` | `string`                                       | Short description shown next to the key badge        |
+| `action`      | `(spread: GC.Spread.Sheets.Workbook) => void`  | Function executed when the full sequence is entered  |
+
+## Guidelines
+
+- **Keys are case-insensitive** — `'h'` and `'H'` are treated the same.
+- **Shared prefixes are merged automatically.** If you add `['H', 'F', 'B']` (Bold) and `['H', 'F', 'I']` (Italic), pressing `Alt → H → F` will show both `B` and `I` as options.
+- **Labels at the same level should be consistent.** If key `H` already maps to label `"Home"`, use the same label in new commands that start with `H`.
+- **Keep sequences short** (2–4 keys) for usability.
+- **Always guard against empty selections** in your action function — the user may trigger the shortcut with no cells selected.
+
+## Example: Adding Bold Toggle
+
+```typescript
+const toggleBold: KeyTipCommand = {
+  keys: ['H', 'F', 'B'],
+  labels: ['Home', 'Font', 'Bold'],
+  description: 'Toggle bold on selected cells',
+  action: (spread) => {
+    const sheet = spread.getActiveSheet();
+    const selections = sheet.getSelections();
+    if (!selections || selections.length === 0) return;
+    const sel = selections[0];
+    const style = sheet.getStyle(sel.row, sel.col) || new GC.Spread.Sheets.Style();
+    const isBold = style.font?.includes('bold');
+    const newStyle = new GC.Spread.Sheets.Style();
+    newStyle.font = isBold ? 'normal 11pt Calibri' : 'bold 11pt Calibri';
+    sheet.getRange(sel.row, sel.col, sel.rowCount, sel.colCount).setStyle(newStyle);
+  },
+};
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,17 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import * as GC from '@mescius/spread-sheets';
 import { SpreadSheets } from '@mescius/spread-sheets-react';
 import '@mescius/spread-sheets/styles/gc.spread.sheets.excel2013white.css';
+import { useKeyTips, KEY_TIP_COMMANDS, KeyTipOverlay } from './keytips';
 import './App.css';
 
 function App() {
   const spreadRef = useRef<any>(null);
+  const [spreadInstance, setSpreadInstance] = useState<GC.Spread.Sheets.Workbook | null>(null);
+  const { state: keyTipState } = useKeyTips(KEY_TIP_COMMANDS, spreadInstance);
 
-  const initSpread = (spread: any) => {
-    console.log('Spread initialized');
+  const initSpread = (spread: GC.Spread.Sheets.Workbook) => {
+    setSpreadInstance(spread);
     const sheet = spread.getActiveSheet();
     
     // Set some initial data
@@ -69,11 +72,12 @@ function App() {
         Meridian Take Home
       </h2>
       <div style={{ flex: 1, position: 'relative' }}>
-        <SpreadSheets 
+        <KeyTipOverlay state={keyTipState} />
+        <SpreadSheets
           ref={spreadRef}
           workbookInitialized={initSpread}
-          hostStyle={{ 
-            width: '100%', 
+          hostStyle={{
+            width: '100%',
             height: '100%',
             position: 'absolute',
             top: 0,

--- a/src/keytips/KeyTipOverlay.css
+++ b/src/keytips/KeyTipOverlay.css
@@ -1,0 +1,144 @@
+/* ── Floating glassmorphism overlay ────────────────────────────── */
+
+.keytip-overlay {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 18px;
+
+  /* Glassmorphism */
+  background: rgba(15, 15, 15, 0.72);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+
+  /* Depth */
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.28),
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+
+  color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  user-select: none;
+  pointer-events: auto;
+  white-space: nowrap;
+
+  animation: keytip-enter 200ms cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+@keyframes keytip-enter {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) scale(0.96) translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) scale(1) translateY(0);
+  }
+}
+
+/* ── Breadcrumb path ──────────────────────────────────────────── */
+
+.keytip-path {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+}
+
+.keytip-path-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 5px;
+  font-family: 'SF Mono', 'Monaco', 'Cascadia Code', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.keytip-path-separator {
+  color: rgba(255, 255, 255, 0.25);
+  font-size: 12px;
+  line-height: 1;
+}
+
+/* ── Divider ──────────────────────────────────────────────────── */
+
+.keytip-divider {
+  width: 1px;
+  height: 22px;
+  background: rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+}
+
+/* ── Available options ────────────────────────────────────────── */
+
+.keytip-options {
+  display: flex;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
+.keytip-option {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px 5px 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  transition: background 150ms ease, border-color 150ms ease;
+  cursor: default;
+}
+
+.keytip-option:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.keytip-option-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  background: rgba(99, 152, 255, 0.85);
+  border-radius: 5px;
+  font-family: 'SF Mono', 'Monaco', 'Cascadia Code', monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  color: #fff;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
+}
+
+.keytip-option-label {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.78);
+  white-space: nowrap;
+}
+
+/* ── Hint ─────────────────────────────────────────────────────── */
+
+.keytip-hint {
+  font-size: 10.5px;
+  color: rgba(255, 255, 255, 0.3);
+  flex-shrink: 0;
+  letter-spacing: 0.1px;
+}

--- a/src/keytips/KeyTipOverlay.tsx
+++ b/src/keytips/KeyTipOverlay.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { KeyTipState } from './types';
+import './KeyTipOverlay.css';
+
+interface KeyTipOverlayProps {
+  state: KeyTipState;
+}
+
+const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+const ACTIVATION_LABEL = isMac ? '\u2318' : 'Alt';
+
+const KeyTipOverlay: React.FC<KeyTipOverlayProps> = ({ state }) => {
+  if (!state.active) return null;
+
+  return (
+    <div className="keytip-overlay" onClick={(e) => e.stopPropagation()}>
+      {/* Breadcrumb path */}
+      <div className="keytip-path">
+        <span className="keytip-path-key">{ACTIVATION_LABEL}</span>
+        {state.path.map((key, i) => (
+          <React.Fragment key={i}>
+            <span className="keytip-path-separator">&rsaquo;</span>
+            <span className="keytip-path-key">{key}</span>
+          </React.Fragment>
+        ))}
+      </div>
+
+      <div className="keytip-divider" />
+
+      {/* Available next keys */}
+      <div className="keytip-options">
+        {state.availableKeys.map((node) => (
+          <div key={node.key} className="keytip-option">
+            <span className="keytip-option-key">{node.key}</span>
+            <span className="keytip-option-label">
+              {node.description ?? node.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="keytip-hint">Esc to cancel</div>
+    </div>
+  );
+};
+
+export default KeyTipOverlay;

--- a/src/keytips/commands.ts
+++ b/src/keytips/commands.ts
@@ -1,0 +1,122 @@
+import * as GC from "@mescius/spread-sheets";
+import { KeyTipCommand } from "./types";
+
+/** Capture clipboard text from any copy/cut within the page — no permissions needed. */
+let lastCopiedText: string | null = null;
+document.addEventListener("copy", (e) => {
+  const text = e.clipboardData?.getData("text/plain");
+  if (text) lastCopiedText = text;
+});
+document.addEventListener("cut", (e) => {
+  const text = e.clipboardData?.getData("text/plain");
+  if (text) lastCopiedText = text;
+});
+
+const getActiveSelection = (spread: GC.Spread.Sheets.Workbook) => {
+  const sheet = spread.getActiveSheet();
+  const selections = sheet.getSelections();
+  if (!selections || selections.length === 0) return null;
+  return { sheet, selection: selections[0] };
+};
+
+/** Alt/Cmd → H → V → V: Paste only values (not formulas) */
+const pasteValues: KeyTipCommand = {
+  keys: ["H", "V", "V"],
+  labels: ["Home", "Paste", "Values"],
+  description: "Paste values",
+  action: (spread) => {
+    if (!lastCopiedText) return;
+    const ctx = getActiveSelection(spread);
+    if (!ctx) return;
+    const { sheet, selection: sel } = ctx;
+    const rows = lastCopiedText.replace(/\r\n$/, "").split(/\r?\n/);
+    spread.suspendPaint();
+    for (let r = 0; r < rows.length; r++) {
+      const cols = rows[r].split("\t");
+      for (let c = 0; c < cols.length; c++) {
+        const raw = cols[c];
+        const num = Number(raw);
+        const value = raw === "" ? null : isNaN(num) ? raw : num;
+        sheet.setValue(sel.row + r, sel.col + c, value);
+      }
+    }
+    spread.resumePaint();
+  },
+};
+
+/** Alt/Cmd → H → B → B: Add bottom border to selected cells */
+const borderBottom: KeyTipCommand = {
+  keys: ["H", "B", "B"],
+  labels: ["Home", "Borders", "Bottom"],
+  description: "Add bottom border to selected cells",
+  action: (spread) => {
+    const ctx = getActiveSelection(spread);
+    if (!ctx) return;
+    const { sheet, selection: sel } = ctx;
+    const border = new GC.Spread.Sheets.LineBorder(
+      "#000000",
+      GC.Spread.Sheets.LineStyle.thin,
+    );
+    sheet
+      .getRange(sel.row, sel.col, sel.rowCount, sel.colCount)
+      .setBorder(border, { bottom: true });
+  },
+};
+
+/** Alt/Cmd → H → B → T: Add top border to selected cells */
+const borderTop: KeyTipCommand = {
+  keys: ["H", "B", "T"],
+  labels: ["Home", "Borders", "Top"],
+  description: "Add top border to selected cells",
+  action: (spread) => {
+    const ctx = getActiveSelection(spread);
+    if (!ctx) return;
+    const { sheet, selection: sel } = ctx;
+    const border = new GC.Spread.Sheets.LineBorder(
+      "#000000",
+      GC.Spread.Sheets.LineStyle.thin,
+    );
+    sheet
+      .getRange(sel.row, sel.col, sel.rowCount, sel.colCount)
+      .setBorder(border, { top: true });
+  },
+};
+
+/** Alt/Cmd → H → O → I: AutoFit column width to fit content */
+const autoFitColumn: KeyTipCommand = {
+  keys: ["H", "O", "I"],
+  labels: ["Home", "Format", "AutoFit Width"],
+  description: "Adjust column width to fit content",
+  action: (spread) => {
+    const ctx = getActiveSelection(spread);
+    if (!ctx) return;
+    const { sheet, selection: sel } = ctx;
+    for (let c = sel.col; c < sel.col + sel.colCount; c++) {
+      sheet.autoFitColumn(c);
+    }
+  },
+};
+
+/** Alt/Cmd → A → S: Sort selected cells in descending order */
+const sortDescending: KeyTipCommand = {
+  keys: ["A", "S"],
+  labels: ["Data", "Sort Descending"],
+  description: "Sort selected cells in descending order",
+  action: (spread) => {
+    const ctx = getActiveSelection(spread);
+    if (!ctx) return;
+    const { sheet, selection: sel } = ctx;
+    sheet.sortRange(sel.row, sel.col, sel.rowCount, sel.colCount, true, [
+      { index: sel.col, ascending: false },
+    ]);
+  },
+};
+
+/** All registered KeyTip commands. Add new commands to this array. */
+export const KEY_TIP_COMMANDS: KeyTipCommand[] = [
+  pasteValues,
+  borderBottom,
+  borderTop,
+  autoFitColumn,
+  sortDescending,
+];

--- a/src/keytips/index.ts
+++ b/src/keytips/index.ts
@@ -1,0 +1,4 @@
+export { useKeyTips } from './useKeyTips';
+export { KEY_TIP_COMMANDS } from './commands';
+export { default as KeyTipOverlay } from './KeyTipOverlay';
+export type { KeyTipCommand, KeyTipNode, KeyTipState } from './types';

--- a/src/keytips/keyTipTree.ts
+++ b/src/keytips/keyTipTree.ts
@@ -1,0 +1,57 @@
+import { KeyTipCommand, KeyTipNode } from './types';
+
+/** Create an empty root node for the trie. */
+const createRootNode = (): KeyTipNode => ({
+  key: '',
+  label: 'Root',
+  children: {},
+});
+
+/** Build a trie from a flat list of KeyTipCommand definitions. */
+export const buildKeyTipTree = (commands: KeyTipCommand[]): KeyTipNode => {
+  const root = createRootNode();
+
+  for (const command of commands) {
+    let current = root;
+
+    for (let i = 0; i < command.keys.length; i++) {
+      const key = command.keys[i].toUpperCase();
+      const label = command.labels[i] ?? key;
+      const isLeaf = i === command.keys.length - 1;
+
+      if (!current.children[key]) {
+        current.children[key] = {
+          key,
+          label,
+          children: {},
+        };
+      }
+
+      if (isLeaf) {
+        current.children[key].action = command.action;
+        current.children[key].description = command.description;
+      }
+
+      current = current.children[key];
+    }
+  }
+
+  return root;
+};
+
+/** Traverse the trie by following a sequence of keys. Returns null if path is invalid. */
+export const traverseTree = (root: KeyTipNode, keys: string[]): KeyTipNode | null => {
+  let current: KeyTipNode = root;
+
+  for (const key of keys) {
+    const upper = key.toUpperCase();
+    if (!current.children[upper]) return null;
+    current = current.children[upper];
+  }
+
+  return current;
+};
+
+/** Get direct children of a node as an array, sorted by key. */
+export const getAvailableKeys = (node: KeyTipNode): KeyTipNode[] =>
+  Object.values(node.children).sort((a, b) => a.key.localeCompare(b.key));

--- a/src/keytips/types.ts
+++ b/src/keytips/types.ts
@@ -1,0 +1,29 @@
+import * as GC from '@mescius/spread-sheets';
+
+/** A single node in the KeyTip trie. Leaf nodes have an `action`. */
+export interface KeyTipNode {
+  key: string;
+  label: string;
+  children: Record<string, KeyTipNode>;
+  action?: (spread: GC.Spread.Sheets.Workbook) => void;
+  description?: string;
+}
+
+/** Flat definition used to register a keytip command. */
+export interface KeyTipCommand {
+  /** Sequential keys after Alt/Cmd activation, e.g. ['H', 'V', 'V'] */
+  keys: string[];
+  /** Human-readable labels for each level, e.g. ['Home', 'Paste', 'Values'] */
+  labels: string[];
+  /** Short description shown in the overlay */
+  description: string;
+  /** Action to execute when the full sequence is entered */
+  action: (spread: GC.Spread.Sheets.Workbook) => void;
+}
+
+export interface KeyTipState {
+  active: boolean;
+  path: string[];
+  currentNode: KeyTipNode | null;
+  availableKeys: KeyTipNode[];
+}

--- a/src/keytips/useKeyTips.ts
+++ b/src/keytips/useKeyTips.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as GC from '@mescius/spread-sheets';
+import { KeyTipCommand, KeyTipState } from './types';
+import { buildKeyTipTree, getAvailableKeys, traverseTree } from './keyTipTree';
+
+const INITIAL_STATE: KeyTipState = {
+  active: false,
+  path: [],
+  currentNode: null,
+  availableKeys: [],
+};
+
+const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+export const useKeyTips = (
+  commands: KeyTipCommand[],
+  spread: GC.Spread.Sheets.Workbook | null,
+) => {
+  const [state, setState] = useState<KeyTipState>(INITIAL_STATE);
+  const tree = useMemo(() => buildKeyTipTree(commands), [commands]);
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  // Track whether the modifier was tapped alone (not part of Cmd+R, etc.)
+  const modifierAloneRef = useRef(false);
+
+  const reset = useCallback(() => setState(INITIAL_STATE), []);
+
+  const activate = useCallback(() => {
+    if (spread) spread.getActiveSheet().endEdit();
+    setState({
+      active: true,
+      path: [],
+      currentNode: tree,
+      availableKeys: getAvailableKeys(tree),
+    });
+  }, [tree, spread]);
+
+  const goBack = useCallback(() => {
+    const current = stateRef.current;
+    if (!current.active) return;
+
+    if (current.path.length === 0) {
+      reset();
+      return;
+    }
+
+    const newPath = current.path.slice(0, -1);
+    const node = newPath.length === 0 ? tree : traverseTree(tree, newPath);
+    if (!node) {
+      reset();
+      return;
+    }
+    setState({
+      active: true,
+      path: newPath,
+      currentNode: node,
+      availableKeys: getAvailableKeys(node),
+    });
+  }, [tree, reset]);
+
+  const handleKeyPress = useCallback((key: string) => {
+    const current = stateRef.current;
+    if (!current.active || !current.currentNode) return;
+
+    const upper = key.toUpperCase();
+    const nextNode = traverseTree(current.currentNode, [upper]);
+
+    if (!nextNode) {
+      reset();
+      return;
+    }
+
+    // Node with action — execute and reset
+    if (nextNode.action && Object.keys(nextNode.children).length === 0) {
+      if (spread) nextNode.action(spread);
+      reset();
+      return;
+    }
+
+    // Intermediate node — advance the path
+    const newPath = [...current.path, upper];
+    setState({
+      active: true,
+      path: newPath,
+      currentNode: nextNode,
+      availableKeys: getAvailableKeys(nextNode),
+    });
+  }, [spread, reset]);
+
+  useEffect(() => {
+    const isActivationKey = (key: string) =>
+      isMac ? key === 'Meta' : key === 'Alt';
+
+    // Runs in CAPTURE phase — fires before SpreadJS sees the event
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const current = stateRef.current;
+
+      // On activation key press, just mark it — don't block the event
+      // so browser combos like Cmd+R still work
+      if (isActivationKey(e.key)) {
+        modifierAloneRef.current = true;
+        return;
+      }
+
+      // Any other key while modifier is held = combo (Cmd+R, Cmd+C, etc.)
+      if (e.metaKey || e.altKey) {
+        modifierAloneRef.current = false;
+      }
+
+      if (!current.active) return;
+
+      // Cancel on Escape
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        reset();
+        return;
+      }
+
+      // Go back on Backspace
+      if (e.key === 'Backspace') {
+        e.preventDefault();
+        e.stopPropagation();
+        goBack();
+        return;
+      }
+
+      // Ignore modifier keys while active
+      if (['Alt', 'Meta', 'Control', 'Shift'].includes(e.key)) return;
+
+      // Block ALL keys from reaching SpreadJS while KeyTips is active
+      if (e.key.length === 1) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleKeyPress(e.key);
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      // Activation: only when modifier was pressed and released alone
+      if (isActivationKey(e.key)) {
+        if (modifierAloneRef.current) {
+          if (stateRef.current.active) {
+            reset();
+          } else {
+            activate();
+          }
+        }
+        modifierAloneRef.current = false;
+        return;
+      }
+
+      // Block keyup from reaching SpreadJS while active
+      if (stateRef.current.active &&
+          !['Alt', 'Meta', 'Control', 'Shift'].includes(e.key)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    const handleClick = () => {
+      if (stateRef.current.active) reset();
+    };
+
+    // Block SpreadJS from entering edit mode while KeyTips is active
+    const blockEdit = (_: any, args: any) => {
+      if (stateRef.current.active) args.cancel = true;
+    };
+    if (spread) {
+      spread.bind(GC.Spread.Sheets.Events.EditStarting, blockEdit);
+    }
+
+    // capture: true = our handler fires BEFORE SpreadJS
+    window.addEventListener('keydown', handleKeyDown, true);
+    window.addEventListener('keyup', handleKeyUp, true);
+    window.addEventListener('click', handleClick);
+
+    return () => {
+      if (spread) {
+        spread.unbind(GC.Spread.Sheets.Events.EditStarting, blockEdit);
+      }
+      window.removeEventListener('keydown', handleKeyDown, true);
+      window.removeEventListener('keyup', handleKeyUp, true);
+      window.removeEventListener('click', handleClick);
+    };
+  }, [activate, reset, handleKeyPress, goBack, spread]);
+
+  return { state, reset };
+};


### PR DESCRIPTION
Fully done in claude code :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds global keyboard event capture and edit-blocking around SpreadJS, which can impact existing shortcuts/focus behavior. Also introduces clipboard-driven paste logic and range mutations that could have edge cases with selections and data types.
> 
> **Overview**
> Adds a new *KeyTips* keyboard shortcut system built on a trie of registered commands, including a `useKeyTips` hook that toggles on Alt (Windows) / Cmd (Mac) and captures key events (Esc to cancel, Backspace to go back) while blocking SpreadJS editing/keystrokes.
> 
> Introduces a glassmorphism `KeyTipOverlay` UI to display the current key path and available next keys, and wires it into `App.tsx` by storing the SpreadJS workbook instance and passing it into the hook.
> 
> Registers initial commands in `commands.ts` (paste values from last copied text, top/bottom borders, autofit columns, sort descending) and adds `keytips.md` documentation describing how to add new commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2d79b69990c1de98cbd68442cf03e8e0da0fd88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->